### PR TITLE
[FIX] Access control problems.

### DIFF
--- a/QRCodeReader/QRCodeReader.swift
+++ b/QRCodeReader/QRCodeReader.swift
@@ -165,7 +165,7 @@ public final class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegat
   }
   
   /// Checks and return whether the given metadata object types are supported by the current device
-  class func supportsMetadataObjectTypes(_ metadataTypes: [String]? = nil) -> Bool {
+  public class func supportsMetadataObjectTypes(_ metadataTypes: [String]? = nil) -> Bool {
     if !isAvailable() {
       return false
     }

--- a/QRCodeReader/QRCodeViewController.swift
+++ b/QRCodeReader/QRCodeViewController.swift
@@ -34,8 +34,8 @@ public final class QRCodeReaderViewController: UIViewController {
   private var cancelButton: UIButton = UIButton()
   private var switchCameraButton: SwitchCameraButton?
   
-  weak var delegate: QRCodeReaderViewControllerDelegate?
-  var completionBlock: ((String?) -> ())?
+  public weak var delegate: QRCodeReaderViewControllerDelegate?
+  public var completionBlock: ((String?) -> ())?
   
   deinit {
     codeReader?.stopScanning()
@@ -191,7 +191,7 @@ public final class QRCodeReaderViewController: UIViewController {
 }
 
 /// This protocol defines delegate methods for objects that implements the `QRCodeReaderDelegate`. The methods of the protocol allow the delegate to be notified when the reader did scan result and or when the user wants to stop to read some QRCodes.
-protocol QRCodeReaderViewControllerDelegate: class {
+public protocol QRCodeReaderViewControllerDelegate: class {
   /// Tells the delegate that the reader did scan a code.
   func reader(reader: QRCodeReaderViewController, didScanResult result: String)
   


### PR DESCRIPTION
QRCodeReader.supportsMetadataObjectTypes, QRCodeViewController.delegate, QRCodeViewController.completionBlock and QRCodeViewControllerDelegate should all be public.