### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides a default view controller to display the camera view with the scan a
 
 ![screenshot](http://yannickloriot.com/resources/qrcodereader.swift-screenshot.jpg)
 
-*Note: the v4.x or over are compatibles with swift 1.2, use the v3 with XCode 6.2 or lower.*
+*Note: the v4.x or over are compatibles with swift 1.2, use the v3 with Xcode 6.2 or lower.*
 
 ## Usage
 


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
