### PR TITLE
Ability to detect camera switch, and to specify starting camera position

### DIFF
--- a/Example/QRCodeReader.swift/ViewController.swift
+++ b/Example/QRCodeReader.swift/ViewController.swift
@@ -29,7 +29,7 @@ import AVFoundation
 
 class ViewController: UIViewController, QRCodeReaderViewControllerDelegate {
   lazy var reader = QRCodeReaderViewController(builder: QRCodeReaderViewControllerBuilder {
-    $0.reader          = QRCodeReader(startingCaptureDevicePosition: .back, metadataObjectTypes: [AVMetadataObjectTypeQRCode])
+    $0.reader          = QRCodeReader(metadataObjectTypes: [AVMetadataObjectTypeQRCode], captureDevicePosition: .back)
     $0.showTorchButton = true
   })
 

--- a/Example/QRCodeReader.swift/ViewController.swift
+++ b/Example/QRCodeReader.swift/ViewController.swift
@@ -29,7 +29,7 @@ import AVFoundation
 
 class ViewController: UIViewController, QRCodeReaderViewControllerDelegate {
   lazy var reader = QRCodeReaderViewController(builder: QRCodeReaderViewControllerBuilder {
-    $0.reader          = QRCodeReader(metadataObjectTypes: [AVMetadataObjectTypeQRCode])
+    $0.reader          = QRCodeReader(startingCaptureDevicePosition: .back, metadataObjectTypes: [AVMetadataObjectTypeQRCode])
     $0.showTorchButton = true
   })
 
@@ -68,17 +68,14 @@ class ViewController: UIViewController, QRCodeReaderViewControllerDelegate {
       self?.present(alert, animated: true, completion: nil)
     }
   }
-
+  
+  func reader(_ reader: QRCodeReaderViewController, didSwitchCamera newCaptureDevice: AVCaptureDeviceInput) {
+    if let cameraName = newCaptureDevice.device.localizedName {
+      print("Switching capturing to: \(cameraName)")
+    }
+  }
+  
   func readerDidCancel(_ reader: QRCodeReaderViewController) {
     dismiss(animated: true, completion: nil)
-  }
-
-  private func createReader() -> QRCodeReaderViewController {
-    let builder = QRCodeReaderViewControllerBuilder { builder in
-      builder.reader          = QRCodeReader(metadataObjectTypes: [AVMetadataObjectTypeQRCode])
-      builder.showTorchButton = true
-    }
-
-    return QRCodeReaderViewController(builder: builder)
   }
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then just follow these steps:
 // Good practice: create the reader lazily to avoid cpu overload during the
 // initialization and each time we need to scan a QRCode
 lazy var readerVC = QRCodeReaderViewController(builder: QRCodeReaderViewControllerBuilder {
-  $0.reader = QRCodeReader(metadataObjectTypes: [AVMetadataObjectTypeQRCode])
+  $0.reader = QRCodeReader(startingCaptureDevicePosition: .back, metadataObjectTypes: [AVMetadataObjectTypeQRCode])
 })
 
 @IBAction func scanAction(_ sender: AnyObject) {
@@ -65,6 +65,14 @@ lazy var readerVC = QRCodeReaderViewController(builder: QRCodeReaderViewControll
 
 func reader(_ reader: QRCodeReader, didScanResult result: QRCodeReaderResult) {
   dismiss(animated: true, completion: nil)
+}
+
+//This is an optional delegate method, that allows you to be notified when the user switches the cameraName
+//By pressing on the switch camera button
+func reader(_ reader: QRCodeReaderViewController, didSwitchCamera newCaptureDevice: AVCaptureDeviceInput) {
+    if let cameraName = newCaptureDevice.device.localizedName {
+      print("Switching capturing to: \(cameraName)")
+    }
 }
 
 func readerDidCancel(_ reader: QRCodeReader) {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then just follow these steps:
 // Good practice: create the reader lazily to avoid cpu overload during the
 // initialization and each time we need to scan a QRCode
 lazy var readerVC = QRCodeReaderViewController(builder: QRCodeReaderViewControllerBuilder {
-  $0.reader = QRCodeReader(startingCaptureDevicePosition: .back, metadataObjectTypes: [AVMetadataObjectTypeQRCode])
+  $0.reader = QRCodeReader(metadataObjectTypes: [AVMetadataObjectTypeQRCode], captureDevicePosition: .back)
 })
 
 @IBAction func scanAction(_ sender: AnyObject) {

--- a/Sources/QRCodeReader.swift
+++ b/Sources/QRCodeReader.swift
@@ -79,31 +79,6 @@ public final class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegat
   public var didFindCode: ((QRCodeReaderResult) -> Void)?
 
   // MARK: - Creating the Code Reade
-  
-  /**
-   Initializes the code reader with the QRCode metadata type object.
-   */
-  public convenience override init() {
-    self.init(startingCaptureDevicePosition: .back)
-  }
-  
-  /**
-   Initializes the code reader with the starting capture device position, and the default array of metadata object types
-   
-   - parameter startingCaptureDevicePosition: The capture position to use on start of scanning
-   */
-  public convenience init(startingCaptureDevicePosition position: AVCaptureDevicePosition) {
-    self.init(startingCaptureDevicePosition: position, metadataObjectTypes: [AVMetadataObjectTypeQRCode])
-  }
-  
-  /**
-   Initializes the code reader with an array of metadata object types, and the default initial capture position
-   
-   - parameter metadataObjectTypes: An array of strings identifying the types of metadata objects to process.
-   */
-  public convenience init(metadataObjectTypes types: [String]) {
-    self.init(startingCaptureDevicePosition: .back, metadataObjectTypes: types)
-  }
 
   /**
    Initializes the code reader with an array of metadata object types.
@@ -111,12 +86,12 @@ public final class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegat
    - parameter startingCaptureDevicePosition: The Camera to use on start of scanning
    - parameter metadataObjectTypes: An array of strings identifying the types of metadata objects to process.
    */
-  public init(startingCaptureDevicePosition: AVCaptureDevicePosition, metadataObjectTypes types: [String]) {
+  public init(metadataObjectTypes types: [String] = [AVMetadataObjectTypeQRCode], captureDevicePosition: AVCaptureDevicePosition = .back) {
     metadataObjectTypes = types
 
     super.init()
 
-    configureDefaultComponents(withCaptureDevicePosition: startingCaptureDevicePosition)
+    configureDefaultComponents(withCaptureDevicePosition: captureDevicePosition)
   }
 
   // MARK: - Initializing the AV Components

--- a/Sources/QRCodeReaderViewController.swift
+++ b/Sources/QRCodeReaderViewController.swift
@@ -90,7 +90,7 @@ public class QRCodeReaderViewController: UIViewController {
   }
 
   required public init?(coder aDecoder: NSCoder) {
-    codeReader             = QRCodeReader(startingCaptureDevicePosition: .back, metadataObjectTypes: [])
+    codeReader             = QRCodeReader()
     startScanningAtLoad    = false
     showCancelButton       = false
     showTorchButton        = false

--- a/Sources/QRCodeReaderViewController.swift
+++ b/Sources/QRCodeReaderViewController.swift
@@ -90,7 +90,7 @@ public class QRCodeReaderViewController: UIViewController {
   }
 
   required public init?(coder aDecoder: NSCoder) {
-    codeReader             = QRCodeReader(metadataObjectTypes: [])
+    codeReader             = QRCodeReader(startingCaptureDevicePosition: .back, metadataObjectTypes: [])
     startScanningAtLoad    = false
     showCancelButton       = false
     showTorchButton        = false
@@ -233,7 +233,9 @@ public class QRCodeReaderViewController: UIViewController {
   }
 
   func switchCameraAction(_ button: SwitchCameraButton) {
-    codeReader.switchDeviceInput()
+    if let newDevice = codeReader.switchDeviceInput() {
+      delegate?.reader(self, didSwitchCamera: newDevice)
+    }
   }
 
   func toggleTorchAction(_ button: ToggleTorchButton) {
@@ -254,9 +256,31 @@ public protocol QRCodeReaderViewControllerDelegate: class {
   func reader(_ reader: QRCodeReaderViewController, didScanResult result: QRCodeReaderResult)
 
   /**
+   Tells the delegate that the camera was switched by the user
+   
+   - parameter reader: A code reader object informing the delegate about the scan result.
+   - parameter newCaptureDevice: The capture device that was switched to
+   */
+  func reader(_ reader: QRCodeReaderViewController, didSwitchCamera newCaptureDevice: AVCaptureDeviceInput)
+  
+  /**
    Tells the delegate that the user wants to stop scanning codes.
 
    - parameter reader: A code reader object informing the delegate about the cancellation.
    */
   func readerDidCancel(_ reader: QRCodeReaderViewController)
+
+}
+
+extension QRCodeReaderViewControllerDelegate {
+  
+  /**
+   Default implementation that No-Ops this callBack
+   
+   - parameter reader: A code reader object informing the delegate about the scan result.
+   - parameter newCaptureDevice: The capture device that was switched to
+   */
+  func reader(_ reader: QRCodeReaderViewController, didSwitchCamera newCaptureDevice: AVCaptureDeviceInput) {
+    
+  }
 }


### PR DESCRIPTION
I have added a constructor parameter (and overloads for convenience) to specify which camera the  scanning should start on.

Further, I have added a delegate method that is notified when the camera is switched.  The delegate will receive the new CaptureDevice that is switched to (When the switch is made, the QRCodeReader now returns the switched-to-device, which is fed through to the delegate).

I have also updated the ReadMe, and the example project to reflect these changes.

Let me know if there's anything else you need me to do to get this merged in.