### PR TITLE
Allows users to override the QRCodeReaderViewController class

### DIFF
--- a/Sources/QRCodeReaderViewController.swift
+++ b/Sources/QRCodeReaderViewController.swift
@@ -28,7 +28,7 @@ import UIKit
 import AVFoundation
 
 /// Convenient controller to display a view to scan/read 1D or 2D bar codes like the QRCodes. It is based on the `AVFoundation` framework from Apple. It aims to replace ZXing or ZBar for iOS 7 and over.
-public class QRCodeReaderViewController: UIViewController {
+open class QRCodeReaderViewController: UIViewController {
   private var cameraView   = ReaderOverlayView()
   private var cancelButton: UIButton?
   private var switchCameraButton: SwitchCameraButton?
@@ -100,11 +100,11 @@ public class QRCodeReaderViewController: UIViewController {
   }
 
   // MARK: - Responding to View Events
-  override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+  override open var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     return parent?.supportedInterfaceOrientations ?? .all
   }
 
-  override public func viewWillAppear(_ animated: Bool) {
+  override open func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
     if startScanningAtLoad {
@@ -112,13 +112,13 @@ public class QRCodeReaderViewController: UIViewController {
     }
   }
 
-  override public func viewWillDisappear(_ animated: Bool) {
+  override open func viewWillDisappear(_ animated: Bool) {
     stopScanning()
 
     super.viewWillDisappear(animated)
   }
 
-  override public func viewWillLayoutSubviews() {
+  override open func viewWillLayoutSubviews() {
     super.viewWillLayoutSubviews()
 
     codeReader.previewLayer.frame = view.bounds


### PR DESCRIPTION
This implements the new open access modifier introduced with Swift 3.0 that allows users to override the class.