### PR TITLE
Optional Overlay View

### DIFF
--- a/Sources/QRCodeReaderView.swift
+++ b/Sources/QRCodeReaderView.swift
@@ -27,7 +27,7 @@
 import UIKit
 
 final class QRCodeReaderView: UIView, QRCodeReaderDisplayable {
-  lazy var overlayView: UIView = {
+  lazy var overlayView: UIView? = {
     let ov = ReaderOverlayView()
 
     ov.backgroundColor                           = .clear
@@ -71,7 +71,7 @@ final class QRCodeReaderView: UIView, QRCodeReaderDisplayable {
     return ttb
   }()
 
-  func setupComponents(showCancelButton: Bool, showSwitchCameraButton: Bool, showTorchButton: Bool) {
+  func setupComponents(showCancelButton: Bool, showSwitchCameraButton: Bool, showTorchButton: Bool, showOverlayView: Bool) {
     translatesAutoresizingMaskIntoConstraints = false
 
     addComponents()
@@ -79,10 +79,11 @@ final class QRCodeReaderView: UIView, QRCodeReaderDisplayable {
     cancelButton?.isHidden       = !showCancelButton
     switchCameraButton?.isHidden = !showSwitchCameraButton
     toggleTorchButton?.isHidden  = !showTorchButton
+    overlayView?.isHidden        = !showOverlayView
 
-    guard let cb = cancelButton, let scb = switchCameraButton, let ttb = toggleTorchButton else { return }
+    guard let cb = cancelButton, let scb = switchCameraButton, let ttb = toggleTorchButton, let ov = overlayView else { return }
 
-    let views = ["cv": cameraView, "ov": overlayView, "cb": cb, "scb": scb, "ttb": ttb]
+    let views = ["cv": cameraView, "ov": ov, "cb": cb, "scb": scb, "ttb": ttb]
 
     addConstraints(NSLayoutConstraint.constraints(withVisualFormat: "H:|[cv]|", options: [], metrics: nil, views: views))
 
@@ -105,7 +106,7 @@ final class QRCodeReaderView: UIView, QRCodeReaderDisplayable {
     }
 
     for attribute in Array<NSLayoutAttribute>([.left, .top, .right, .bottom]) {
-      addConstraint(NSLayoutConstraint(item: overlayView, attribute: attribute, relatedBy: .equal, toItem: cameraView, attribute: attribute, multiplier: 1, constant: 0))
+      addConstraint(NSLayoutConstraint(item: ov, attribute: attribute, relatedBy: .equal, toItem: cameraView, attribute: attribute, multiplier: 1, constant: 0))
     }
   }
 
@@ -113,7 +114,10 @@ final class QRCodeReaderView: UIView, QRCodeReaderDisplayable {
 
   private func addComponents() {
     addSubview(cameraView)
-    addSubview(overlayView)
+
+    if let ov = overlayView {
+      addSubview(ov)
+    }
 
     if let scb = switchCameraButton {
       addSubview(scb)

--- a/Sources/QRCodeReaderViewContainer.swift
+++ b/Sources/QRCodeReaderViewContainer.swift
@@ -40,6 +40,9 @@ public protocol QRCodeReaderDisplayable {
   /// A toggle torch button.
   var toggleTorchButton: UIButton? { get }
 
+  /// A guide view upon the camera view
+  var overlayView: UIView? { get }
+
   /**
    Method called by the container to allows you to layout your view properly using the given flags.
    
@@ -47,7 +50,7 @@ public protocol QRCodeReaderDisplayable {
    - Parameter showSwitchCameraButton: Flag to know whether you should display the switch camera button.
    - Parameter showTorchButton: Flag to know whether you should display the toggle torch button.
    */
-  func setupComponents(showCancelButton: Bool, showSwitchCameraButton: Bool, showTorchButton: Bool)
+  func setupComponents(showCancelButton: Bool, showSwitchCameraButton: Bool, showTorchButton: Bool, showOverlayView: Bool)
 }
 
 /// The `QRCodeReaderContainer` structure embed the view displayed by the controller. The embeded view must be conform to the `QRCodeReaderDisplayable` protocol.
@@ -67,7 +70,7 @@ public struct QRCodeReaderContainer {
 
   // MARK: - Convenience Methods
 
-  func setupComponents(showCancelButton: Bool, showSwitchCameraButton: Bool, showTorchButton: Bool) {
-    displayable.setupComponents(showCancelButton: showCancelButton, showSwitchCameraButton: showSwitchCameraButton, showTorchButton: showTorchButton)
+  func setupComponents(showCancelButton: Bool, showSwitchCameraButton: Bool, showTorchButton: Bool, showOverlayView: Bool) {
+    displayable.setupComponents(showCancelButton: showCancelButton, showSwitchCameraButton: showSwitchCameraButton, showTorchButton: showTorchButton, showOverlayView: showOverlayView)
   }
 }

--- a/Sources/QRCodeReaderViewController.swift
+++ b/Sources/QRCodeReaderViewController.swift
@@ -37,6 +37,7 @@ public class QRCodeReaderViewController: UIViewController {
   let showCancelButton: Bool
   let showSwitchCameraButton: Bool
   let showTorchButton: Bool
+  let showOverlayView: Bool
 
   // MARK: - Managing the Callback Responders
 
@@ -66,6 +67,7 @@ public class QRCodeReaderViewController: UIViewController {
     showCancelButton       = builder.showCancelButton
     showSwitchCameraButton = builder.showSwitchCameraButton
     showTorchButton        = builder.showTorchButton
+    showOverlayView        = builder.showOverlayView
 
     super.init(nibName: nil, bundle: nil)
 
@@ -90,6 +92,7 @@ public class QRCodeReaderViewController: UIViewController {
     showCancelButton       = false
     showTorchButton        = false
     showSwitchCameraButton = false
+    showOverlayView        = false
 
     super.init(coder: aDecoder)
   }
@@ -137,7 +140,7 @@ public class QRCodeReaderViewController: UIViewController {
     let sscb = showSwitchCameraButton && codeReader.hasFrontDevice
     let stb  = showTorchButton && codeReader.isTorchAvailable
 
-    readerView.setupComponents(showCancelButton: showCancelButton, showSwitchCameraButton: sscb, showTorchButton: stb)
+    readerView.setupComponents(showCancelButton: showCancelButton, showSwitchCameraButton: sscb, showTorchButton: stb, showOverlayView: showOverlayView)
 
     // Setup action methods
 

--- a/Sources/QRCodeReaderViewControllerBuilder.swift
+++ b/Sources/QRCodeReaderViewControllerBuilder.swift
@@ -74,6 +74,12 @@ public final class QRCodeReaderViewControllerBuilder {
    */
   public var showTorchButton = false
 
+  /**
+    Flag to display the guide view.
+  */
+  public var showOverlayView = true
+    
+
   // MARK: - Initializing a Flap View
 
   /**


### PR DESCRIPTION
# Optional Overlay View
Most views/buttons on the preview layer are all optional and can opt-out, but not overlay view for guide yet. Also, there can be some apps which wants great QRCode reader as well as wants to design their own view. Therefore, I tried to hide the overlay view. I'm sorry for late pull request, but please look over this if possible.
## Change notes
1. Add “overlayView“ in QRCodeReaderDisplayable because now it can be hidden.
2. “overlayView” in QRCodeReaderView now becomes optional.
3. “setupComponents” method in QRCodeReaderView now set `isHidden` value of overlayView. Although it’s optional, it’s surely created but set hidden if required in the method.
4. To set overlayView hidden, QRCodeReaderViewControllerBuilder now has showOverlayView value. Default value is true.