### PR TITLE
Xcode 7 Swift 2.2 Build failed, argument must be optionnal

### DIFF
--- a/Sources/SwitchCameraButton.swift
+++ b/Sources/SwitchCameraButton.swift
@@ -178,7 +178,7 @@ public final class SwitchCameraButton: UIButton {
     setNeedsDisplay()
   }
 
-  public override func touchesCancelled(touches: Set<UITouch>, withEvent event: UIEvent?) {
+  public override func touchesCancelled(touches: Set<UITouch>?, withEvent event: UIEvent?) {
     super.touchesCancelled(touches, withEvent: event)
 
     setNeedsDisplay()

--- a/Sources/ToggleTorchButton.swift
+++ b/Sources/ToggleTorchButton.swift
@@ -117,7 +117,7 @@ public final class ToggleTorchButton: UIButton {
     setNeedsDisplay()
   }
 
-  public override func touchesCancelled(touches: Set<UITouch>, withEvent event: UIEvent?) {
+  public override func touchesCancelled(touches: Set<UITouch>?, withEvent event: UIEvent?) {
     super.touchesCancelled(touches, withEvent: event)
 
     setNeedsDisplay()


### PR DESCRIPTION
The build failed if "touches: Set<UITouch>" is not optionnal

I use Xcode 7 and swift 2.2