### PR TITLE
Fixed crash bug when a QR Code string could not be decoded and result…

### DIFF
--- a/Sources/QRCodeReaderView.swift
+++ b/Sources/QRCodeReaderView.swift
@@ -110,6 +110,30 @@ final class QRCodeReaderView: UIView, QRCodeReaderDisplayable {
     }
   }
 
+  // MARK: - Scan Result Indication
+  
+  func startTimerForBorderReset() {
+    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+      if let ovl = self.overlayView as? ReaderOverlayView {
+        ovl.overlayColor = .white
+      }
+    }
+  }
+  
+  func addRedBorder() {
+    self.startTimerForBorderReset()
+    if let ovl = self.overlayView as? ReaderOverlayView {
+      ovl.overlayColor = .red
+    }
+  }
+  
+  func addGreenBorder() {
+    self.startTimerForBorderReset()
+    if let ovl = self.overlayView as? ReaderOverlayView {
+      ovl.overlayColor = .green
+    }
+  }
+  
   // MARK: - Convenience Methods
 
   private func addComponents() {

--- a/Sources/QRCodeReaderViewController.swift
+++ b/Sources/QRCodeReaderViewController.swift
@@ -75,11 +75,22 @@ public class QRCodeReaderViewController: UIViewController {
 
     codeReader.didFindCode = { [weak self] resultAsObject in
       if let weakSelf = self {
+        if let qrv = weakSelf.readerView.displayable as? QRCodeReaderView {
+          qrv.addGreenBorder()
+        }
         weakSelf.completionBlock?(resultAsObject)
         weakSelf.delegate?.reader(weakSelf, didScanResult: resultAsObject)
       }
     }
 
+    codeReader.didFailDecoding = { [weak self] in
+      if let weakSelf = self {
+        if let qrv = weakSelf.readerView.displayable as? QRCodeReaderView {
+          qrv.addRedBorder()
+        }
+      }
+    }
+    
     setupUIComponentsWithCancelButtonTitle(builder.cancelButtonTitle)
 
     NotificationCenter.default.addObserver(self, selector: #selector(orientationDidChange), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)

--- a/Sources/ReaderOverlayView.swift
+++ b/Sources/ReaderOverlayView.swift
@@ -56,6 +56,13 @@ public final class ReaderOverlayView: UIView {
     layer.addSublayer(overlay)
   }
 
+  var overlayColor: UIColor = UIColor.white {
+    didSet {
+      self.overlay.strokeColor = overlayColor.cgColor
+      self.setNeedsDisplay()
+    }
+  }
+  
   public override func draw(_ rect: CGRect) {
     var innerRect = rect.insetBy(dx: 50, dy: 50)
     let minSize   = min(innerRect.width, innerRect.height)


### PR DESCRIPTION
…ed in unwrapping of nil.
Also added border color change to indicate the issue with a red color.

As stated by Apple, the AVMetadataMachineReadableCodeObject.string can actually be nil and in that case, the previous code would crash.

I have not yet managed to figure out why the QRCode string could not be decoded. I have a particular QRCode from the Hermes Parcel Service with my own full address and that of another person, so I can naturally not attach that for debug purposes :-)
I suspect that either Hermes is doing something weird or there is a problem with the string encoding, which Apples framework does not handle correctly.
I tried to scan the QRCode with the Qrafter App and that actually worked, but I do not know what kind of code scanner it uses.
OK, before this gets tl;dr; - please consider releasing at least the unwrapping safe guard. The overlay border color change is a nice to have (for the user) to see that a code was found but could not be read.