### PR TITLE
open class instead of public class QRCodeReaderViewController

### DIFF
--- a/Sources/QRCodeReaderViewController.swift
+++ b/Sources/QRCodeReaderViewController.swift
@@ -28,7 +28,7 @@ import UIKit
 import AVFoundation
 
 /// Convenient controller to display a view to scan/read 1D or 2D bar codes like the QRCodes. It is based on the `AVFoundation` framework from Apple. It aims to replace ZXing or ZBar for iOS 7 and over.
-public class QRCodeReaderViewController: UIViewController {
+open class QRCodeReaderViewController: UIViewController {
   /// The code reader object used to scan the bar code.
   public let codeReader: QRCodeReader
 


### PR DESCRIPTION
Allowing inheritance from the class QRCodeReaderViewController on app classes. Solution for the following XCode error message: Cannot inherit from non-open class 'QRCodeReaderViewController' outside of its defining module.