### PR TITLE
Get ride of lazy init of previewLayer. Fixes #120

### DIFF
--- a/Sources/QRCodeReader.swift
+++ b/Sources/QRCodeReader.swift
@@ -75,9 +75,7 @@ public final class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegat
   // MARK: - Managing the Properties
 
   /// CALayer that you use to display video as it is being captured by an input device.
-  public lazy var previewLayer: AVCaptureVideoPreviewLayer = {
-    return AVCaptureVideoPreviewLayer(session: self.session)
-  }()
+  public let previewLayer: AVCaptureVideoPreviewLayer
 
   /// An array of object identifying the types of metadata objects to process.
   public let metadataObjectTypes: [AVMetadataObject.ObjectType]
@@ -128,7 +126,7 @@ public final class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegat
    */
   public init(metadataObjectTypes types: [AVMetadataObject.ObjectType], captureDevicePosition: AVCaptureDevice.Position) {
     metadataObjectTypes = types
-
+    previewLayer = AVCaptureVideoPreviewLayer(session: session)
     super.init()
 
     sessionQueue.async {


### PR DESCRIPTION
**previewLayer** variable can't be lazy. It's possible to call it from different threads, which is the source of issue #120 