### PR TITLE
NSInternalInconsistencyException is thrown, fixed to run in main thread

### DIFF
--- a/Sources/QRCodeReader.swift
+++ b/Sources/QRCodeReader.swift
@@ -130,7 +130,7 @@ public final class QRCodeReader: NSObject, AVCaptureMetadataOutputObjectsDelegat
 
     super.init()
 
-    sessionQueue.async {
+    DispatchQueue.main.async {
       self.configureDefaultComponents(withCaptureDevicePosition: captureDevicePosition)
     }
   }


### PR DESCRIPTION
```
Fatal Exception: NSInternalInconsistencyException
Modifications to the layout engine must not be performed from a background thread after it has been accessed from the main thread.
```
Updating AVCaptureVideoPreviewLayer may very rarely be done in a background thread when QRCodeReader is initialized.
It seems to be an issue related to [#188](https://github.com/yannickl/QRCodeReader.swift/issues/188)